### PR TITLE
Added example of multiple TraitHandlers to traits contrib README.

### DIFF
--- a/evennia/contrib/rpg/traits/README.md
+++ b/evennia/contrib/rpg/traits/README.md
@@ -439,3 +439,42 @@ class Character(DefaultCharacter):
     rage = TraitProperty("A dark mood", rage=30, trait_type='rage')
 
 ```
+
+## Adding additional TraitHandlers
+
+Sometimes, it is easier to top-level classify traits, such as stats, skills, or other categories of traits you want to handle independantly of each other. Here is an example showing an example on the object typeclass, expanding on the first installation example:
+
+```python
+# mygame/typeclasses/objects.py
+
+from evennia import DefaultCharacter
+from evennia.utils import lazy_property
+from evennia.contrib.rpg.traits import TraitHandler
+
+# ...
+
+class Character(DefaultCharacter):
+    ...
+    @lazy_property
+    def traits(self):
+        # this adds the handler as .traits
+        return TraitHandler(self)
+    
+    @lazy_property
+    def stats(self):
+        # this adds the handler as .stats
+        return TraitHandler(self, db_attribute_key="stats")
+
+    @lazy_property
+    def skills(self):
+        # this adds the handler as .skills
+        return TraitHandler(self, db_attribute_key="skills")
+
+
+    def at_object_creation(self):
+        # (or wherever you want)
+        self.stats.add("str", "Strength", trait_type="static", base=10, mod=2)
+        self.traits.add("hp", "Health", trait_type="gauge", min=0, max=100)
+        self.skills.add("hunting", "Hunting Skill", trait_type="counter",
+                        base=10, mod=1, min=0, max=100)
+```


### PR DESCRIPTION
Added section at bottom addressing adding additional TraitHandlers. 

Shows example based on first example, but instead using a stats, skills and the original TraitHandler.

#### Brief overview of PR changes/additions

Added example at bottom of traits contrib README that expanded first example, but instead breaks the three traits into a stats, skills and traits TraitHandler.

#### Motivation for adding to Evennia

Useful functionality that should be easily accessible to other users from initial read to prevent later refactoring.

#### Other info (issues closed, discussion etc)
